### PR TITLE
Use nginx/gunicorn in docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM django:python2-onbuild
+FROM python:2.7
 MAINTAINER dan.leehr@duke.edu
 
+RUN apt-get update && apt-get install -y \
+		gcc \
+		gettext \
+		mysql-client libmysqlclient-dev \
+		postgresql-client libpq-dev \
+		sqlite3 \
+	--no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
 COPY handoverservice/settings.docker /usr/src/app/handoverservice/settings.py
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,6 @@ services:
     entrypoint:
       - /usr/src/app/handoverservice/wait-for-postgres.sh
       - db
+    # docker-compose doesn't allow specifying the entrypoint while preserving
+    # the Dockerfile's command
     command: python manage.py runserver 0.0.0.0:8000

--- a/handoverservice/settings.docker
+++ b/handoverservice/settings.docker
@@ -38,3 +38,5 @@ DDSCLIENT_PROPERTIES = {
   'url': os.getenv('HANDOVERSERVICE_DDSCLIENT_URL'),
   'agent_key': os.getenv('HANDOVERSERVICE_DDSCLIENT_AGENT_KEY'),
 }
+
+STATIC_ROOT='/usr/src/app/static'

--- a/handoverservice/settings_base.py
+++ b/handoverservice/settings_base.py
@@ -105,7 +105,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/'
+STATIC_URL = '/static/'
 
 # Email
 # For development we'll just use the console backend.

--- a/handoverservice/settings_base.py
+++ b/handoverservice/settings_base.py
@@ -105,7 +105,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/'
 
 # Email
 # For development we'll just use the console backend.

--- a/production.yml
+++ b/production.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  db:
+    extends:
+      file: docker-compose.yml
+      service: db
+  web:
+    extends:
+      file: docker-compose.yml
+      service: web
+    build: ./production
+    image: dukegcb/dukedshandoverservice:production
+    ports:
+      - "80:80"
+   entrypoint:
+     - /usr/src/app/handoverservice/wait-for-postgres.sh
+     - db

--- a/production.yml
+++ b/production.yml
@@ -1,17 +1,11 @@
 version: '2'
 services:
-  db:
-    extends:
-      file: docker-compose.yml
-      service: db
   web:
-    extends:
-      file: docker-compose.yml
-      service: web
     build: ./production
     image: dukegcb/dukedshandoverservice:production
     ports:
       - "80:80"
-   entrypoint:
-     - /usr/src/app/handoverservice/wait-for-postgres.sh
-     - db
+    # docker-compose doesn't allow specifying the entrypoint while preserving the
+    # Dockerfile's command. Since the base docker-compose file specifies an entrypoint
+    # we must provide the command here.
+    command: supervisord -c /etc/supervisord.conf -n

--- a/production.yml
+++ b/production.yml
@@ -5,6 +5,9 @@ services:
     image: dukegcb/dukedshandoverservice:production
     ports:
       - "80:80"
+      - "443:443"
+    volumes:
+      -/etc/ssl/external/:/etc/ssl/external/
     # docker-compose doesn't allow specifying the entrypoint while preserving the
     # Dockerfile's command. Since the base docker-compose file specifies an entrypoint
     # we must provide the command here.

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -18,6 +18,12 @@ RUN python manage.py collectstatic --noinput
 # Reset the variable to an empty string, requiring it to be provided at runtime
 ENV HANDOVERSERVICE_SECRET_KEY=''
 
+# Volume for SSL certificates
+
+VOLUME /etc/ssl/external/
+
 EXPOSE 80
+EXPOSE 443
+
 CMD supervisord -c /etc/supervisord.conf -n
 

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,0 +1,23 @@
+FROM dukegcb/dukedshandoverservice
+MAINTAINER dan.leehr@duke.edu
+
+# nginx / supervisor
+RUN apt-get update && apt-get install -y nginx
+RUN pip install supervisor supervisor-stdout
+
+ADD supervisord.conf /etc/supervisord.conf
+ADD nginx.conf /etc/nginx/nginx.conf
+
+RUN service nginx stop
+
+# Place static files using manage.py
+# Running any manage.py commands require a secret key to be present
+# in the django app's settings.py.
+ENV HANDOVERSERVICE_SECRET_KEY=secret
+RUN python manage.py collectstatic --noinput
+# Reset the variable to an empty string, requiring it to be provided at runtime
+ENV HANDOVERSERVICE_SECRET_KEY=''
+
+EXPOSE 80
+CMD supervisord -c /etc/supervisord.conf -n
+

--- a/production/nginx.conf
+++ b/production/nginx.conf
@@ -25,7 +25,14 @@ http {
         listen 80 default;
         client_max_body_size 4G;
         server_name _;
+        rewrite ^ https://$http_host$request_uri? permanent;    # force redirect http to https
+    }
 
+    server {
+        listen 443;
+        ssl on;
+        ssl_certificate /etc/ssl/external/cacert.pem;
+        ssl_certificate_key /etc/ssl/external/privkey.pem;
         keepalive_timeout 5;
 
         location /static {

--- a/production/nginx.conf
+++ b/production/nginx.conf
@@ -28,15 +28,12 @@ http {
 
         keepalive_timeout 5;
 
-        # path for static files
-        root /usr/src/app/static;
-
-        location / {
-            # checks for static file, if not found proxy to app
-            try_files $uri @proxy_to_app;
+        location /static {
+            autoindex on;
+            alias /usr/src/app/static/;
         }
 
-        location @proxy_to_app {
+        location / {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;
             proxy_redirect off;

--- a/production/nginx.conf
+++ b/production/nginx.conf
@@ -1,0 +1,48 @@
+daemon off;
+error_log /dev/stdout info;
+worker_processes 1;
+
+# user nobody nogroup;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+    accept_mutex off;
+}
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+    access_log /dev/stdout combined;
+    sendfile on;
+
+    upstream app_server {
+        # For a TCP configuration:
+        server 127.0.0.1:8000 fail_timeout=0;
+    }
+
+    server {
+        listen 80 default;
+        client_max_body_size 4G;
+        server_name _;
+
+        keepalive_timeout 5;
+
+        # path for static files
+        root /usr/src/app/static;
+
+        location / {
+            # checks for static file, if not found proxy to app
+            try_files $uri @proxy_to_app;
+        }
+
+        location @proxy_to_app {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+
+            proxy_pass   http://app_server;
+        }
+
+    }
+}

--- a/production/supervisord.conf
+++ b/production/supervisord.conf
@@ -1,0 +1,19 @@
+[supervisord]
+nodaemon = true
+
+[program:nginx]
+command = /usr/sbin/nginx
+startsecs = 5
+stdout_events_enabled = true
+stderr_events_enabled = true
+
+[program:app-gunicorn]
+command = gunicorn handoverservice.wsgi -w 4 -b 127.0.0.1:8000 --log-level=debug --chdir=/usr/src/app
+stdout_events_enabled = true
+stderr_events_enabled = true
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ django-filter==0.13.0
 djangorestframework==3.3.3
 DukeDSClient==0.2.3
 funcsigs==0.4
+gunicorn==19.4.5
 mock==1.3.0
 passlib==1.6.5
 pbr==1.8.1


### PR DESCRIPTION
Reworks base dockerfile to not be onbuild
Creates a second dockerfile/docker-compose override to run the application with supervisord/gunicorn/nginx
nginx is configured for SSL on 443
SSL cert and key must be mounted in /etc/ssl/external/