### PR TITLE
Simplifies perform_handover by not removing the from_user

### DIFF
--- a/handover_api/tests_utils.py
+++ b/handover_api/tests_utils.py
@@ -16,7 +16,3 @@ class UtilsTestCaseHandover(TestCase):
         perform_handover(h)
         MockDDSUtil.assert_any_call(h.from_user_id)
         mock_ddsutil.add_user.assert_called_with(h.to_user_id, h.project_id, 'project_admin')
-        MockDDSUtil.assert_any_call(h.to_user_id)
-        mock_ddsutil.remove_user.assert_called_with(h.from_user_id, h.project_id)
-
-

--- a/handover_api/utils.py
+++ b/handover_api/utils.py
@@ -65,7 +65,7 @@ def send_handover(handover, accept_url):
 
 def perform_handover(handover):
     """
-    Communicates with DukeDS via DDSUtil to add the to_user to a project, and remove the from_user.
+    Communicates with DukeDS via DDSUtil to add the to_user to a project
     :param handover: A Handover object
     :return:
     """
@@ -75,8 +75,15 @@ def perform_handover(handover):
         ddsutil_from = DDSUtil(handover.from_user_id)
         ddsutil_from.add_user(handover.to_user_id, handover.project_id, auth_role)
 
-        # Now remove the from_user from the project, acting as the to_user
-        ddsutil_to = DDSUtil(handover.to_user_id)
-        ddsutil_to.remove_user(handover.from_user_id, handover.project_id)
+        # At this point, We'd like to remove the from_user from the project, changing ownership
+        # However, we cannot remove the from_user if we are authenticated as that user
+        # We experimented with authenticating as the to_user, but this was not practical
+        # as we are not able to register our application to receive credentials from
+        # the duke-authentication service. The alternative was to require all recipients
+        # to obtain API keys and register them our service, but this is a poor user experience
+        # We hope to simplify this if the from_user can remove himself/herself from the
+        # project after he/she has added the to_user:
+        # https://github.com/Duke-Translational-Bioinformatics/duke-data-service/issues/577
+
     except ValueError as e:
         raise RuntimeError('Unable to retrieve information from DukeDS: {}'.format(e.message))


### PR DESCRIPTION
This removes the need for the to_user to pre-register an API key, but handed-over projects will now have two owners: the original sender and the recipient