### PR TITLE
Enable WSGIPassAuthorization to restore token auth

### DIFF
--- a/production/handoverservice.conf
+++ b/production/handoverservice.conf
@@ -15,6 +15,8 @@ Alias /static/ /usr/src/app/static/
 # WSGI
 WSGIScriptAlias / /usr/src/app/handoverservice/wsgi.py
 WSGIPythonPath /usr/src/app
+# Pass authorization headers to python app, such as api tokens
+WSGIPassAuthorization On
 
 <Directory /usr/src/app>
   <Files wsgi.py>


### PR DESCRIPTION
Fixes #43